### PR TITLE
Ticker-tape animation: move CSS transitions into JS

### DIFF
--- a/client-projects/the-lumery/index.ts
+++ b/client-projects/the-lumery/index.ts
@@ -23,6 +23,7 @@ import { swapOutTaglines } from "./swapOutTaglines";
 import { setUpFilterButtons } from "./filterButtons";
 import { setUpImageAnimation } from "./cardImages";
 import { letterboxScroll } from "./betterTogether";
+import { setUpTickerTapeLink } from "./tickerTapeLink";
 
 document.addEventListener("DOMContentLoaded", () => {
   if (!prefersReducedMotion()) {
@@ -61,17 +62,8 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   // ticker tape effect (CSS animation, found on 'yesterday' and 'tomorrow' pages)
-  const tickerTapeLink = document.querySelector(TICKER_TAPE_SELECTOR);
-  if (tickerTapeLink) {
-    onlyPlayWhenVisible(TICKER_TAPE_SELECTOR);
-
-    // the ticker tape should pause on hover
-    tickerTapeLink?.addEventListener("mouseover", () =>
-      pauseAnimations(TICKER_TAPE_SELECTOR),
-    );
-    tickerTapeLink?.addEventListener("mouseout", () =>
-      resumeAnimations(TICKER_TAPE_SELECTOR),
-    );
+  if (document.querySelector(TICKER_TAPE_SELECTOR)) {
+    setUpTickerTapeLink();
   }
 
   // ytdefer is an alternative to loading the 2.5MB base.js from the standard YouTube embed

--- a/client-projects/the-lumery/scss/ticker-tape-animation.scss
+++ b/client-projects/the-lumery/scss/ticker-tape-animation.scss
@@ -2,12 +2,12 @@ body,
 .page-wrapper {
   overflow-x: hidden;
 }
+
 .ticker-tape {
   display: inline-block;
   animation-name: scroll-ticker-tape;
   animation-timing-function: linear;
   animation-iteration-count: infinite;
-  animation-play-state: running;
   animation-duration: 120s;
 
   @include mobile-portrait-down {
@@ -21,21 +21,11 @@ body,
   }
 }
 
-.ticker-tape__text {
-  text-decoration-line: underline;
-  text-decoration-color: transparent;
-  text-decoration-thickness: 3px;
-
-  .ticker-tape__link:hover & {
-    --color-black: #1e1e1e;
-
-    color: var(--color-black);
-    text-decoration-color: var(--color-black);
-  }
+.ticker-tape__link:focus {
+  outline: none;
 }
-
-.ticker-tape__link:hover .reduced-motion {
-  text-decoration-line: underline;
-  text-decoration-color: var(--color-black);
-  text-decoration-thickness: 3px;
+.ticker-tape__link:focus .ticker-tape,
+.ticker-tape__link:focus .ticker-tape__text--static {
+  outline-offset: 2px;
+  outline: 2px solid var(--color-purple-light);
 }

--- a/client-projects/the-lumery/tickerTapeLink.ts
+++ b/client-projects/the-lumery/tickerTapeLink.ts
@@ -1,0 +1,50 @@
+import { TICKER_TAPE_SELECTOR, TICKER_TAPE_TEXT_SELECTOR } from "./selectors";
+import {
+  onlyPlayWhenVisible,
+  pauseAnimations,
+  resumeAnimations,
+} from "./utils";
+
+export function setUpTickerTapeLink() {
+  const tickerTapeLink = document.querySelector(TICKER_TAPE_SELECTOR);
+  if (!(tickerTapeLink instanceof HTMLAnchorElement)) {
+    throw new Error(
+      `ticker tape link not found, or not an <a> element: ${tickerTapeLink}`,
+    );
+  }
+
+  onlyPlayWhenVisible(TICKER_TAPE_SELECTOR);
+
+  const texts: NodeListOf<HTMLDivElement> = tickerTapeLink.querySelectorAll(
+    TICKER_TAPE_TEXT_SELECTOR,
+  );
+  if (texts.length === 0) {
+    throw new Error(`Ticker tape texts not found ${TICKER_TAPE_TEXT_SELECTOR}`);
+  }
+
+  texts.forEach((text) => {
+    // As I'm using JS to stop and start the animations, all other interactive
+    // style changes on this element are also done in JS, rather than CSS
+    text.style.textDecorationLine = "underline";
+    text.style.textDecorationThickness = "3px";
+    text.style.textDecorationColor = "transparent";
+    text.style.textUnderlineOffset = "0.1em";
+  });
+
+  const setUnderlineColor = (color: "#fff" | "transparent") => {
+    texts.forEach((text) => {
+      text.style.textDecorationColor = color;
+    });
+  };
+
+  //  on hover, the ticker tape should pause and the text should underline
+  tickerTapeLink?.addEventListener("mouseover", () => {
+    setUnderlineColor("#fff");
+    pauseAnimations(TICKER_TAPE_SELECTOR);
+  });
+
+  tickerTapeLink?.addEventListener("mouseout", () => {
+    setUnderlineColor("transparent");
+    resumeAnimations(TICKER_TAPE_SELECTOR);
+  });
+}


### PR DESCRIPTION
As I had hijacked the animation with Javascript (in the `onlyPlayWhenVisible` function), CSS hover effects were not working properly. Moving them to JS fixes it.